### PR TITLE
LibMan dependency automatically solved, removed from requirements

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "microsoft.web.librarymanager.cli": {
+      "version": "3.0.71",
+      "commands": [
+        "libman"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/PaintWar.csproj
+++ b/PaintWar.csproj
@@ -7,7 +7,8 @@
   </PropertyGroup>
 
   <Target Name="RestoreClientSideLibraries" BeforeTargets="Build" Condition="!Exists('wwwroot/js/signalr/signalr.js')">
-    <Exec Command="libman restore" />
+    <Exec Command="dotnet tool restore" />
+    <Exec Command="dotnet tool run libman restore" />
   </Target>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -14,13 +14,6 @@ The Paint War Team
 # Requirements
 
 - [.NET SDK 9.*](https://dotnet.microsoft.com/en-us/download/dotnet/9.0)
-- [LibMan](https://learn.microsoft.com/aspnet/core/client-side/libman)
-
-Install LibMan with:
-
-```bash
-dotnet tool install -g Microsoft.Web.LibraryManager.Cli
-```
 
 # Building
 


### PR DESCRIPTION
Adds LibMan locally when running `dotnet run`, so that there's no need to install it globally using:
```bash
dotnet tool install -g Microsoft.Web.LibraryManager.Cli
```

Those who have in installed globally can remove it by using:
```bash
dotnet tool uninstall -g Microsoft.Web.LibraryManager.Cli
```